### PR TITLE
Add ability to change timezone via public property.

### DIFF
--- a/src/google_proxy.php
+++ b/src/google_proxy.php
@@ -17,7 +17,7 @@ class GoogleCalendarProxy {
 	private $cal;
 	private $cal_name;
 
-	public $timezone = false;
+	public $timezone = "Europe/Minsk";
 	public $outputAll = false;
 	
 	public function __construct($email, $id, $key, $calendar = false) {

--- a/src/google_proxy.php
+++ b/src/google_proxy.php
@@ -17,6 +17,10 @@ class GoogleCalendarProxy {
 	private $cal;
 	private $cal_name;
 
+	/**
+	 * Calendar timezone
+	 * @var string
+	 */
 	public $timezone = "Europe/Minsk";
 	public $outputAll = false;
 	

--- a/src/google_proxy.php
+++ b/src/google_proxy.php
@@ -162,10 +162,10 @@ class GoogleCalendarProxy {
 	private function updateEvent($ev, $data){
 		$data["start"] = array( 
 			"dateTime" => $this->to_gDate($data["start_date"]), 
-			"timeZone" => "Europe/Minsk"	);
+			"timeZone" => $this->timezone	);
 		$data["end"]   = array( 
 			"dateTime" => $this->to_gDate($data["end_date"]),
-			"timeZone" => "Europe/Minsk"	);
+			"timeZone" => $this->timezone	);
 		$data["summary"] = $data["text"];
 
 		try{
@@ -187,13 +187,12 @@ class GoogleCalendarProxy {
 
 
 	private function insertEvent($data) {
-		$timezone = isset($data["timezone"]) ? $data["timezone"]: "00:00";
 		$data["start"] = array( 
 			"dateTime" => $this->to_gDate($data["start_date"]), 
-			"timeZone" => "Europe/Minsk"	);
+			"timeZone" => $this->timezone	);
 		$data["end"]   = array( 
 			"dateTime" => $this->to_gDate($data["end_date"]),
-			"timeZone" => "Europe/Minsk"	);
+			"timeZone" => $this->timezone	);
 		$data["summary"] = $data["text"];
 		unset($data["id"]);
 

--- a/src/google_proxy.php
+++ b/src/google_proxy.php
@@ -19,6 +19,8 @@ class GoogleCalendarProxy {
 
 	/**
 	 * Calendar timezone
+	 * Allowable values - IANA Time Zone Database names http://www.iana.org/time-zones
+	 * or false for autodetection.
 	 * @var string
 	 */
 	public $timezone = "Europe/Minsk";


### PR DESCRIPTION
Timezone can be set with timezone GoogleCalendarProxy property.
E.g.

```
$calendar = new GoogleCalendarProxy(/*calendar settings*/);
$calendar->timezone = "Australia/Tasmania";
```

If timezone property is set to false timezone from google caledar will be used.
By default timezone property is set to "Europe/Minsk", so if timezone wasn't redefined it should work as previously.
